### PR TITLE
Conserta erro de compilação

### DIFF
--- a/lab2/xeu_utils/Command.cpp
+++ b/lab2/xeu_utils/Command.cpp
@@ -2,6 +2,7 @@
 
 #include <sstream>
 #include <string>
+#include <cstring>
 #include <vector>
 
 namespace xeu_utils {


### PR DESCRIPTION
Inclui cstring, por causa do memcpy().

Erro:
xeu_utils/Command.cpp: In member function ‘void xeu_utils::Command::add_arg(const string&)’:
xeu_utils/Command.cpp:54:38: error: ‘memcpy’ was not declared in this scope
   memcpy(n, arg.c_str(), arg.length());