### PR TITLE
Issue fix

### DIFF
--- a/lab_mem/memory_management/Mapper.py
+++ b/lab_mem/memory_management/Mapper.py
@@ -3,12 +3,28 @@ import sys
 class Mapper:
 
     def processAddrs(self):
+        out = ""
         for line in sys.stdin:
             v_addr = int(line, 16)
             if v_addr < 0:
-                return
-            address, n_page_faults = self.map(v_addr)
-            sys.stdout.write(str(address)+" "+str(n_page_faults)+"\n")
+                return out
+            hw_address, frame_id, n_pagefaults = self.map(v_addr)
+            out += (str(hw_address)+" "+str(frame_id)+" "+str(n_pagefaults)+"\n")
+        return out
 
-    def map(self, addr):
-        return (addr, 0)
+    def map(self, virtual_address)
+        """ 
+            Parameters
+            ----------
+            virtual_address : an integer that represents the virtual address to be translated
+
+            Returns
+            -------
+            (hw_address, frame_id, n_pagefaults)
+            where:
+                hw_address: physical address translated
+                frame_id: frame id index where hw_address is stored
+                n_pagefaults: number of possibly page faults thrown
+            
+        """
+        raise NotImplemented 


### PR DESCRIPTION
- [x] Change map( ) interface to 
        `map(int virtual_address) -> (int hw_address, int frame_id, int n_pagefaults)`
- [x]  Removing prints from Mapper.py (return string instead)